### PR TITLE
feat: Add BalanceStr field to AccountBalanceResponse

### DIFF
--- a/examples/account_test.go
+++ b/examples/account_test.go
@@ -33,6 +33,7 @@ func TestGetAccountBalance(t *testing.T) {
 		t.Error(err)
 	}
 	fmt.Println("==========etherscanResp============")
+	fmt.Println(etherscanResp.BalanceStr)
 	fmt.Println(etherscanResp.Balance.Int())
 	fmt.Println(etherscanResp.Account)
 	fmt.Println(etherscanResp.Symbol)

--- a/explorer/etherscan/account.go
+++ b/explorer/etherscan/account.go
@@ -34,6 +34,7 @@ func (cea *ChainExplorerAdaptor) GetAccountBalance(req *account.AccountBalanceRe
 	return &account.AccountBalanceResponse{
 		Account:         req.Account[0],
 		Balance:         balance,
+		BalanceStr:      balance.Int().String(),
 		Symbol:          req.Symbol[0],
 		ContractAddress: req.ContractAddress[0],
 		TokenId:         "0x0",


### PR DESCRIPTION
## Description
This PR adds the `BalanceStr` field to the `AccountBalanceResponse`, providing a string representation of the balance for easier use in frontend or API consumers.

## Changes
- Added `BalanceStr` field to `AccountBalanceResponse`
- Added test to verify `BalanceStr` is printed correctly

## Related Issue
Closes #11