### PR TITLE
Support oklink nft details

### DIFF
--- a/common/account/account.go
+++ b/common/account/account.go
@@ -28,6 +28,33 @@ type AccountBalanceResponse struct {
 	TokenId         string         `json:"token_id"`
 }
 
+type GetAccountBalanceRequest struct {
+	ChainShortName  string   `json:"chainShortName"`
+	ExplorerName    string   `json:"explorerName"`
+	Account         []string `json:"account"`
+	Symbol          string   `json:"symbol"`
+	ContractAddress string   `json:"contractAddress"`
+	ProtocolType    string   `json:"protocolType"`
+	Page            string   `json:"page"`
+	Limit           string   `json:"limit"`
+}
+
+type GetAccountBalanceResponse struct {
+	Page        string    `json:"page"`
+	Limit       string    `json:"limit"`
+	TotalPage   string    `json:"totalPage"`
+	BalanceList []Balance `json:"balanceList"`
+}
+
+type Balance struct {
+	Account         string         `json:"account"`
+	Balance         *common.BigInt `json:"balance"`
+	BalanceStr      string         `json:"balanceStr"`
+	Symbol          string         `json:"symbol"`
+	ContractAddress string         `json:"contractAddress"`
+	TokenId         string         `json:"token_id"`
+}
+
 type AccountUtxoRequest struct {
 	ExplorerName   string `json:"explorerName"`
 	ChainShortName string `json:"chainShortName"`

--- a/common/account/account.go
+++ b/common/account/account.go
@@ -32,9 +32,9 @@ type GetAccountBalanceRequest struct {
 	ChainShortName  string   `json:"chainShortName"`
 	ExplorerName    string   `json:"explorerName"`
 	Account         []string `json:"account"`
-	Symbol          string   `json:"symbol"`
 	ContractAddress string   `json:"contractAddress"`
-	ProtocolType    string   `json:"protocolType"`
+	TokenType       string   `json:"tokenType"`    // 原生代币：native 合约代币：contract
+	ProtocolType    string   `json:"protocolType"` // 20代币：token_20; 721代币：token_721; 1155代币：token_1155;
 	Page            string   `json:"page"`
 	Limit           string   `json:"limit"`
 }

--- a/common/token/token.go
+++ b/common/token/token.go
@@ -66,6 +66,13 @@ type TokenResponse struct {
 	Decimal              string `json:"decimal"`     //  default 1
 }
 
+type Token721Response struct {
+	TokenSymbol   string `json:"TokenSymbol"`
+	TokenAddress  string `json:"TokenAddress"`
+	TokenName     string `json:"TokenName"`
+	TokenQuantity string `json:"TokenQuantity"`
+}
+
 type GetNFTDetailsRequest struct {
 	ExplorerName    string `json:"explorerName"`
 	ChainShortName  string `json:"chainShortName"`

--- a/common/token/token.go
+++ b/common/token/token.go
@@ -66,6 +66,41 @@ type TokenResponse struct {
 	Decimal              string `json:"decimal"`     //  default 1
 }
 
+type GetNFTDetailsRequest struct {
+	ExplorerName    string `json:"explorerName"`
+	ChainShortName  string `json:"chainShortName"`
+	ContractAddress string `json:"contractAddress"`
+	TokenId         string `json:"tokenId"`
+}
+
+type GetNFTDetailsResponse struct {
+	CollectionName       string       `json:"collectionName"`       // Project name (full name)
+	TokenContractAddress string       `json:"tokenContractAddress"` // Project contract address
+	TokenId              string       `json:"tokenId"`              // NFT token ID
+	ProtocolType         string       `json:"protocolType"`         // NFT contract type
+	Token                string       `json:"token"`                // Token name
+	OwnerAddress         string       `json:"ownerAddress"`         // NFT holder address
+	LogoUrl              string       `json:"logoUrl"`              // NFT image URL
+	LastPrice            string       `json:"lastPrice"`            // Latest price of the NFT
+	FloorPrice           string       `json:"floorPrice"`           // Floor price of the NFT
+	LastPriceUnit        string       `json:"lastPriceUnit"`        // Price unit
+	LastTransactionTime  string       `json:"lastTransactionTime"`  // Latest transaction time, Unix timestamp in milliseconds, e.g., 1597026383085
+	LastHeight           string       `json:"lastHeight"`           // Block height of the latest transaction
+	LastTxid             string       `json:"lastTxid"`             // Hash of the latest transaction
+	TransactionCount     string       `json:"transactionCount"`     // Number of transactions for this NFT
+	MinterAddress        string       `json:"minterAddress"`        // NFT creator address
+	StorageMethod        string       `json:"storageMethod"`        // NFT storage method
+	MintTime             string       `json:"mintTime"`             // NFT minting time
+	Title                string       `json:"title"`                // Name property in NFT metadata, can be ENS or DID
+	Attributes           []Attributes `json:"attributes"`           // Attributes
+}
+
+type Attributes struct {
+	TraitType  string `json:"traitType"`  // Attribute category
+	Value      string `json:"value"`      // Attribute value
+	Prevalence string `json:"prevalence"` // Attribute rarity, expressed as decimal, 0.1=10%
+}
+
 // IsStandardProtocol Determine whether the given protocol type is a standard token protocol
 func IsStandardProtocol(protocolType string) bool {
 	switch protocolType {

--- a/examples/account_test.go
+++ b/examples/account_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -172,4 +173,42 @@ func TestTokenGetMultiAccountBalance(t *testing.T) {
 		fmt.Println(oklinkRespItem.Account)
 	}
 	fmt.Println("==========Multi Token OklinkResp============")
+}
+
+func TestGetAccountBalanceV2(t *testing.T) {
+	oklinkClient, _, err := NewMockClient()
+	if err != nil {
+		fmt.Println("new mock client fail", "err", err)
+	}
+	//accountItem := []string{"0x28C6c06298d514Db089934071355E5743bf21d60", "0xF17ACEd3c7A8DAA29ebb90Db8D1b6efD8C364a18"}
+	accountItem := []string{"0x4D392a08f8198a8E56c58BDaB6D01E99Ab33c086"}
+	acbr := &account.GetAccountBalanceRequest{
+		ChainShortName:  "ETH",
+		ExplorerName:    "etherescan",
+		Account:         accountItem,
+		Symbol:          "ETH",
+		ContractAddress: "0xF39c410Dac956BA98004f411E182FB4EEd595270",
+		ProtocolType:    "token_721",
+		Page:            "1",
+		Limit:           "10",
+	}
+	//etherscanResp, err := etherscanClient.GetAccountBalanceV2(acbr)
+	//if err != nil {
+	//	t.Error(err)
+	//}
+	//fmt.Println("==========etherscanResp============")
+	//fmt.Println(etherscanResp.BalanceStr)
+	//fmt.Println(etherscanResp.Balance.Int())
+	//fmt.Println(etherscanResp.Account)
+	//fmt.Println(etherscanResp.Symbol)
+	//fmt.Println("===========etherscanResp===========")
+
+	oklinkResp, err := oklinkClient.GetAccountBalanceV2(acbr)
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Println("==========oklinkResp============")
+	jsonBytes, _ := json.Marshal(oklinkResp)
+	fmt.Printf("%s\n", string(jsonBytes))
+	fmt.Println("==========oklinkResp============")
 }

--- a/examples/account_test.go
+++ b/examples/account_test.go
@@ -176,39 +176,59 @@ func TestTokenGetMultiAccountBalance(t *testing.T) {
 }
 
 func TestGetAccountBalanceV2(t *testing.T) {
-	oklinkClient, _, err := NewMockClient()
+	oklinkClient, etherscanClient, err := NewMockClient()
 	if err != nil {
 		fmt.Println("new mock client fail", "err", err)
 	}
-	//accountItem := []string{"0x28C6c06298d514Db089934071355E5743bf21d60", "0xF17ACEd3c7A8DAA29ebb90Db8D1b6efD8C364a18"}
+	// accountItem := []string{"0x28C6c06298d514Db089934071355E5743bf21d60", "0xF17ACEd3c7A8DAA29ebb90Db8D1b6efD8C364a18"}
 	accountItem := []string{"0x4D392a08f8198a8E56c58BDaB6D01E99Ab33c086"}
 	acbr := &account.GetAccountBalanceRequest{
 		ChainShortName:  "ETH",
 		ExplorerName:    "etherescan",
 		Account:         accountItem,
-		Symbol:          "ETH",
 		ContractAddress: "0xF39c410Dac956BA98004f411E182FB4EEd595270",
+		TokenType:       "contract",
 		ProtocolType:    "token_721",
 		Page:            "1",
 		Limit:           "10",
 	}
-	//etherscanResp, err := etherscanClient.GetAccountBalanceV2(acbr)
-	//if err != nil {
-	//	t.Error(err)
-	//}
-	//fmt.Println("==========etherscanResp============")
-	//fmt.Println(etherscanResp.BalanceStr)
-	//fmt.Println(etherscanResp.Balance.Int())
-	//fmt.Println(etherscanResp.Account)
-	//fmt.Println(etherscanResp.Symbol)
-	//fmt.Println("===========etherscanResp===========")
+	// accountItem := []string{"0xE0554a476A092703abdB3Ef35c80e0D76d32939F"}
+	// acbr := &account.GetAccountBalanceRequest{
+	// 	ChainShortName:  "ETH",
+	// 	ExplorerName:    "etherescan",
+	// 	Account:         accountItem,
+	// 	ContractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+	// 	TokenType:       "contract",
+	// 	ProtocolType:    "token_20",
+	// 	Page:            "1",
+	// 	Limit:           "10",
+	// }
+	// accountItem := []string{"0x5eE84D30c7EE57F63f71c92247Ff31f95E26916B"}
+	// acbr := &account.GetAccountBalanceRequest{
+	// 	ChainShortName:  "ETH",
+	// 	ExplorerName:    "etherescan",
+	// 	Account:         accountItem,
+	// 	ContractAddress: "",
+	// 	TokenType:       "native",
+	// 	ProtocolType:    "",
+	// 	Page:            "1",
+	// 	Limit:           "10",
+	// }
+	etherscanResp, err := etherscanClient.GetAccountBalanceV2(acbr)
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Println("==========etherscanResp============")
+	jsonBytes, _ := json.Marshal(etherscanResp)
+	fmt.Printf("%s\n", string(jsonBytes))
+	fmt.Println("===========etherscanResp===========")
 
 	oklinkResp, err := oklinkClient.GetAccountBalanceV2(acbr)
 	if err != nil {
 		t.Error(err)
 	}
 	fmt.Println("==========oklinkResp============")
-	jsonBytes, _ := json.Marshal(oklinkResp)
+	jsonBytes, _ = json.Marshal(oklinkResp)
 	fmt.Printf("%s\n", string(jsonBytes))
 	fmt.Println("==========oklinkResp============")
 }

--- a/examples/mock.go
+++ b/examples/mock.go
@@ -13,7 +13,7 @@ var (
 	//EtherscanApiKey  = "HZEZGEPJJDA633N421AYW9NE8JFNZZC7JT"
 	//EtherscanTimeout = time.Second * 20
 
-	OklinkBaseUrl = "https://www.oklink.com"
+	OklinkBaseUrl = "https://www.oklink.com/"
 	OklinkApiKey  = "5181d535-b68f-41cf-bbc6-25905e46b6a6"
 	OkTimeout     = time.Second * 20
 

--- a/examples/token_test.go
+++ b/examples/token_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -56,14 +57,15 @@ func TestOklinkGetNFTDetails(t *testing.T) {
 	trps := &token.GetNFTDetailsRequest{
 		ExplorerName:    "oklink",
 		ChainShortName:  "ETH",
-		ContractAddress: "0xed5af388653567af2f388e6224dc7c4b3241c544",
-		TokenId:         "5401",
+		ContractAddress: "0xf39c410dac956ba98004f411e182fb4eed595270",
+		TokenId:         "956",
 	}
 	okResp, err := oklinkClient.GetNFTDetails(trps)
 	if err != nil {
 		t.Error(err)
 	}
 	fmt.Println("=========okRespList=============")
-	fmt.Println(okResp)
+	jsonBytes, _ := json.Marshal(okResp)
+	fmt.Printf("%s\n", string(jsonBytes))
 	fmt.Println("===========okRespList===========")
 }

--- a/examples/token_test.go
+++ b/examples/token_test.go
@@ -47,3 +47,23 @@ func TestOklinkGetETHToken(t *testing.T) {
 	}
 	fmt.Println("===========okRespList===========")
 }
+
+func TestOklinkGetNFTDetails(t *testing.T) {
+	oklinkClient, _, err := NewMockClient()
+	if err != nil {
+		fmt.Println("new mock client fail", "err", err)
+	}
+	trps := &token.GetNFTDetailsRequest{
+		ExplorerName:    "oklink",
+		ChainShortName:  "ETH",
+		ContractAddress: "0xed5af388653567af2f388e6224dc7c4b3241c544",
+		TokenId:         "5401",
+	}
+	okResp, err := oklinkClient.GetNFTDetails(trps)
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Println("=========okRespList=============")
+	fmt.Println(okResp)
+	fmt.Println("===========okRespList===========")
+}

--- a/explorer/base/client.go
+++ b/explorer/base/client.go
@@ -171,7 +171,7 @@ func (bc *BaseClient) Call(name, module, action, apiUrl string, param map[string
 		err = fmt.Errorf("response status %v %s, response body: %s", res.StatusCode, res.Status, content.String())
 		return
 	}
-	fmt.Println("response:", content.String())
+	// fmt.Println("response:", content.String())
 	// When deserializing, The field names must be consistent
 	if name == "etherscan" {
 		err = bc.HandleEtherscanResponse(action, content.Bytes(), outcome)

--- a/explorer/base/client.go
+++ b/explorer/base/client.go
@@ -171,7 +171,7 @@ func (bc *BaseClient) Call(name, module, action, apiUrl string, param map[string
 		err = fmt.Errorf("response status %v %s, response body: %s", res.StatusCode, res.Status, content.String())
 		return
 	}
-	// fmt.Println("response:", content.String())
+	fmt.Println("response:", content.String())
 	// When deserializing, The field names must be consistent
 	if name == "etherscan" {
 		err = bc.HandleEtherscanResponse(action, content.Bytes(), outcome)

--- a/explorer/base/client.go
+++ b/explorer/base/client.go
@@ -171,6 +171,7 @@ func (bc *BaseClient) Call(name, module, action, apiUrl string, param map[string
 		err = fmt.Errorf("response status %v %s, response body: %s", res.StatusCode, res.Status, content.String())
 		return
 	}
+	// fmt.Println("response:", content.String())
 	// When deserializing, The field names must be consistent
 	if name == "etherscan" {
 		err = bc.HandleEtherscanResponse(action, content.Bytes(), outcome)

--- a/explorer/etherscan/account.go
+++ b/explorer/etherscan/account.go
@@ -3,10 +3,12 @@ package etherscan
 import (
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/dapplink-labs/chain-explorer-api/common"
 	"github.com/dapplink-labs/chain-explorer-api/common/account"
 	"github.com/dapplink-labs/chain-explorer-api/common/chain"
+	"github.com/dapplink-labs/chain-explorer-api/common/token"
 )
 
 func (cea *ChainExplorerAdaptor) GetAccountBalance(req *account.AccountBalanceRequest) (*account.AccountBalanceResponse, error) {
@@ -187,6 +189,129 @@ func (cea *ChainExplorerAdaptor) GetTxByAddress(request *account.AccountTxReques
 }
 
 func (cea *ChainExplorerAdaptor) GetAccountBalanceV2(request *account.GetAccountBalanceRequest) (*account.GetAccountBalanceResponse, error) {
-	//todo implement
-	return nil, errors.New("not implement")
+	var result *account.GetAccountBalanceResponse
+	if request.TokenType == "contract" {
+		if len(request.Account) > 1 {
+			return nil, errors.New("etherscan not support multi account contract token balance")
+		} else {
+			switch request.ProtocolType {
+			case "token_20":
+				balance := new(common.BigInt)
+				param := common.M{
+					"contractaddress": request.ContractAddress,
+					"address":         request.Account[0],
+					"tag":             "latest",
+				}
+				err := cea.baseClient.Call("etherscan", "account", "tokenbalance", "", param, &balance)
+				if err != nil {
+					fmt.Println("err", err)
+					return nil, err
+				}
+				symbol := ""
+				tokenInfo, _ := cea.GetTokenList(&token.TokenRequest{
+					ContractAddress: request.ContractAddress,
+				})
+				if len(tokenInfo) > 0 {
+					symbol = tokenInfo[0].Symbol
+				}
+				var balanceItems []account.Balance
+				balanceItems = append(balanceItems, account.Balance{
+					Account:         request.Account[0],
+					Balance:         balance,
+					BalanceStr:      balance.Int().String(),
+					Symbol:          symbol,
+					ContractAddress: request.ContractAddress,
+				})
+				result = &account.GetAccountBalanceResponse{
+					Page:        "1",
+					Limit:       "1",
+					TotalPage:   "1",
+					BalanceList: balanceItems,
+				}
+			case "token_721":
+				var token721List []token.Token721Response
+				param := common.M{
+					"address": request.Account[0],
+					"page":    request.Page,
+					"offset":  request.Limit,
+				}
+				err := cea.baseClient.Call("etherscan", "account", "addresstokennftbalance", "", param, &token721List)
+				if err != nil {
+					fmt.Println("err", err)
+					return nil, err
+				}
+				var balanceItems []account.Balance
+				for _, token721 := range token721List {
+					balance, _ := new(big.Int).SetString(token721.TokenQuantity, 10)
+					balanceItems = append(balanceItems, account.Balance{
+						Account:         request.Account[0],
+						Balance:         (*common.BigInt)(balance),
+						BalanceStr:      token721.TokenQuantity,
+						Symbol:          token721.TokenSymbol,
+						ContractAddress: token721.TokenAddress,
+					})
+				}
+				result = &account.GetAccountBalanceResponse{
+					Page:        request.Page,
+					Limit:       request.Limit,
+					TotalPage:   "",
+					BalanceList: balanceItems,
+				}
+			case "token_1155":
+				return nil, errors.New("etherscan not support account contract token_1155 balance")
+			}
+		}
+	} else {
+		var balanceItems []account.Balance
+		if len(request.Account) > 1 {
+			param := common.M{
+				"tag":     "latest",
+				"address": request.Account,
+			}
+			balances := make([]AccountBalance, 0, len(request.Account))
+			err := cea.baseClient.Call("etherscan", "account", "balancemulti", "", param, &balances)
+			if err != nil {
+				fmt.Println("err", err)
+				return nil, err
+			}
+			if len(balances) > 0 {
+				for _, balance := range balances {
+					balanceItems = append(balanceItems,
+						account.Balance{
+							Account:    balance.Account,
+							Balance:    balance.Balance,
+							BalanceStr: balance.Balance.Int().String(),
+							Symbol:     "ETH"})
+				}
+			} else {
+				balanceItems = append(balanceItems,
+					account.Balance{
+						Account:    "",
+						Balance:    (*common.BigInt)(big.NewInt(0)),
+						BalanceStr: "0",
+						Symbol:     "ETH"})
+			}
+		} else {
+			balance := new(common.BigInt)
+			param := common.M{
+				"tag":     "latest",
+				"address": request.Account[0],
+			}
+			err := cea.baseClient.Call("etherscan", "account", "balance", "", param, balance)
+			if err != nil {
+				fmt.Println("err", err)
+				return nil, err
+			}
+			balanceItems = append(balanceItems,
+				account.Balance{
+					Account:    request.Account[0],
+					Balance:    balance,
+					BalanceStr: balance.Int().String(),
+					Symbol:     "ETH"})
+		}
+		result = &account.GetAccountBalanceResponse{
+			BalanceList: balanceItems,
+		}
+	}
+	return result, nil
 }

--- a/explorer/etherscan/account.go
+++ b/explorer/etherscan/account.go
@@ -1,6 +1,7 @@
 package etherscan
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/dapplink-labs/chain-explorer-api/common"
@@ -183,4 +184,9 @@ func (cea *ChainExplorerAdaptor) GetTxByAddress(request *account.AccountTxReques
 		PageResponse:    pageResponse,
 		TransactionList: transactionList,
 	}, nil
+}
+
+func (cea *ChainExplorerAdaptor) GetAccountBalanceV2(request *account.GetAccountBalanceRequest) (*account.GetAccountBalanceResponse, error) {
+	//todo implement
+	return nil, errors.New("not implement")
 }

--- a/explorer/etherscan/token.go
+++ b/explorer/etherscan/token.go
@@ -2,6 +2,7 @@ package etherscan
 
 import (
 	"fmt"
+
 	"github.com/dapplink-labs/chain-explorer-api/common"
 	"github.com/dapplink-labs/chain-explorer-api/common/token"
 )
@@ -27,4 +28,8 @@ func (cea *ChainExplorerAdaptor) GetTokenList(req *token.TokenRequest) ([]token.
 		tokenList = append(tokenList, tokenItem)
 	}
 	return tokenList, nil
+}
+
+func (cea *ChainExplorerAdaptor) GetNFTDetails(request *token.GetNFTDetailsRequest) (*token.GetNFTDetailsResponse, error) {
+	return nil, fmt.Errorf("not support")
 }

--- a/explorer/etherscan/types.go
+++ b/explorer/etherscan/types.go
@@ -1,10 +1,11 @@
 package etherscan
 
 import (
-	"github.com/dapplink-labs/chain-explorer-api/common"
-	"github.com/dapplink-labs/chain-explorer-api/common/chain"
 	"net/url"
 	"strconv"
+
+	"github.com/dapplink-labs/chain-explorer-api/common"
+	"github.com/dapplink-labs/chain-explorer-api/common/chain"
 )
 
 type TransactionResponse[T any] struct {

--- a/explorer/exploreradaptor.go
+++ b/explorer/exploreradaptor.go
@@ -25,4 +25,8 @@ type ChainExplorerAdaptor interface {
 	GetEstimateGasFee(req *gas_fee.GasEstimateFeeRequest) (*gas_fee.GasEstimateFeeResponse, error)
 	// GetTxByHash 根据交易hash获取交易信息
 	GetTxByHash(request *transaction.TxRequest) (*transaction.TxResponse, error)
+	// GetAccountBalanceV2
+	GetAccountBalanceV2(req *account.GetAccountBalanceRequest) (*account.GetAccountBalanceResponse, error)
+	// GetNFTDetails
+	GetNFTDetails(req *token.GetNFTDetailsRequest) (*token.GetNFTDetailsResponse, error)
 }

--- a/explorer/oklink/account.go
+++ b/explorer/oklink/account.go
@@ -33,7 +33,7 @@ func (cea *ChainExplorerAdaptor) GetAccountBalance(request *account.AccountBalan
 			TokenId:         "0x00",
 		}
 	} else {
-		apiUrl := fmt.Sprintf("api/v5/explorer/address/token-balance?chainShortName=%s&address=%s&tokenContractAddress=%s&protocolType=%s&limit=%d", request.ChainShortName, request.Account[0], request.ContractAddress[0], request.ProtocolType[0], request.Limit[0])
+		apiUrl := fmt.Sprintf("api/v5/explorer/address/token-balance?chainShortName=%s&address=%s&tokenContractAddress=%s&protocolType=%s&limit=%s", request.ChainShortName, request.Account[0], request.ContractAddress[0], request.ProtocolType[0], request.Limit[0])
 		fmt.Println(apiUrl)
 		var responseData []AddressTokenBalanceData
 		err := cea.baseClient.Call("oklink", "", "", apiUrl, nil, &responseData)
@@ -195,3 +195,149 @@ func StringToUint64(s string, defaultValue uint64) uint64 {
 	}
 	return value
 }
+
+func (cea *ChainExplorerAdaptor) GetAccountBalanceV2(request *account.GetAccountBalanceRequest) (*account.GetAccountBalanceResponse, error) {
+	var result *account.GetAccountBalanceResponse
+	if request.ContractAddress == "0x00" {
+		apiUrl := fmt.Sprintf("api/v5/explorer/address/address-summary?chainShortName=%s&address=%s", request.ChainShortName, request.Account[0])
+		var responseData []AddressSummaryData
+		err := cea.baseClient.Call("oklink", "", "", apiUrl, nil, &responseData)
+		if err != nil {
+			fmt.Println("error is:", err)
+			return nil, err
+		}
+		data := responseData[0]
+		balance, _ := new(big.Int).SetString(data.Balance, 10)
+		balanceItems := []account.Balance{
+			{
+				Account:         data.Address,
+				Balance:         (*common.BigInt)(balance),
+				BalanceStr:      data.Balance,
+				Symbol:          data.BalanceSymbol,
+				ContractAddress: data.CreateContractAddress,
+				TokenId:         "0x00",
+			},
+		}
+		result = &account.GetAccountBalanceResponse{
+			Page:        "1",
+			Limit:       "1",
+			TotalPage:   "1",
+			BalanceList: balanceItems,
+		}
+	} else {
+		apiUrl := fmt.Sprintf("api/v5/explorer/address/token-balance?chainShortName=%s&address=%s&protocolType=%s&tokenContractAddress=%s&page=%s&limit=%s", request.ChainShortName, request.Account[0], request.ProtocolType, request.ContractAddress, request.Page, request.Limit)
+		fmt.Println(apiUrl)
+		var responseData []AddressTokenBalanceData
+		err := cea.baseClient.Call("oklink", "", "", apiUrl, nil, &responseData)
+		if err != nil {
+			return nil, err
+		}
+		balance, _ := new(big.Int).SetString(responseData[0].TokenList[0].HoldingAmount, 10)
+		abrps = &account.AccountBalanceResponse{
+			Account:         request.Account[0],
+			Balance:         (*common.BigInt)(balance),
+			BalanceStr:      responseData[0].TokenList[0].HoldingAmount,
+			Symbol:          responseData[0].TokenList[0].Symbol,
+			ContractAddress: responseData[0].TokenList[0].TokenContractAddress,
+			TokenId:         responseData[0].TokenList[0].TokenId,
+		}
+	}
+	return abrps, nil
+}
+
+// // GET /api/v5/explorer/address/address-summary?chainShortName=eth&address=0x85c6627c4ed773cb7c32644b041f58a058b00d30
+// func (cea *ChainExplorerAdaptor) GetAccountBalance(request *account.AccountBalanceRequest) (*account.AccountBalanceResponse, error) {
+// 	var abrps *account.AccountBalanceResponse
+// 	if request.ContractAddress[0] == "0x00" {
+// 		apiUrl := fmt.Sprintf("api/v5/explorer/address/address-summary?chainShortName=%s&address=%s", request.ChainShortName, request.Account[0])
+// 		var responseData []AddressSummaryData
+// 		err := cea.baseClient.Call("oklink", "", "", apiUrl, nil, &responseData)
+// 		if err != nil {
+// 			fmt.Println("error is:", err)
+// 			return nil, err
+// 		}
+// 		balance, _ := new(big.Int).SetString(responseData[0].Balance, 10)
+// 		abrps = &account.AccountBalanceResponse{
+// 			Account:         responseData[0].Address,
+// 			Balance:         (*common.BigInt)(balance),
+// 			BalanceStr:      responseData[0].Balance,
+// 			Symbol:          responseData[0].BalanceSymbol,
+// 			ContractAddress: responseData[0].CreateContractAddress,
+// 			TokenId:         "0x00",
+// 		}
+// 	} else {
+// 		apiUrl := fmt.Sprintf("api/v5/explorer/address/token-balance?chainShortName=%s&address=%s&tokenContractAddress=%s&protocolType=%s&limit=%s", request.ChainShortName, request.Account[0], request.ContractAddress[0], request.ProtocolType[0], request.Limit[0])
+// 		fmt.Println(apiUrl)
+// 		var responseData []AddressTokenBalanceData
+// 		err := cea.baseClient.Call("oklink", "", "", apiUrl, nil, &responseData)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 		fmt.Println(responseData)
+// 		fmt.Println(responseData[0].TokenList)
+// 		balance, _ := new(big.Int).SetString(responseData[0].TokenList[0].HoldingAmount, 10)
+// 		abrps = &account.AccountBalanceResponse{
+// 			Account:         request.Account[0],
+// 			Balance:         (*common.BigInt)(balance),
+// 			BalanceStr:      responseData[0].TokenList[0].HoldingAmount,
+// 			Symbol:          responseData[0].TokenList[0].Symbol,
+// 			ContractAddress: responseData[0].TokenList[0].TokenContractAddress,
+// 			TokenId:         responseData[0].TokenList[0].TokenId,
+// 		}
+// 	}
+// 	return abrps, nil
+// }
+
+// func (cea *ChainExplorerAdaptor) GetMultiAccountBalance(request *account.AccountBalanceRequest) ([]*account.AccountBalanceResponse, error) {
+// 	var abrpsList []*account.AccountBalanceResponse
+// 	addressStr := make([]string, len(request.Account))
+// 	for i, v := range request.Account {
+// 		addressStr[i] = fmt.Sprintf("%s", v)
+// 	}
+// 	result := strings.Join(addressStr, ",")
+// 	if request.ContractAddress[0] == "0x00" {
+// 		apiUrl := fmt.Sprintf("api/v5/explorer/address/balance-multi?chainShortName=%s&address=%s", request.ChainShortName, result)
+// 		var responseData []AddressBalanceMultiData
+// 		err := cea.baseClient.Call("oklink", "", "", apiUrl, nil, &responseData)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 		for _, dataValue := range responseData {
+// 			for _, value := range dataValue.BalanceList {
+// 				balance, _ := new(big.Int).SetString(value.Balance, 10)
+// 				abrps := &account.AccountBalanceResponse{
+// 					Account:         value.Address,
+// 					Balance:         (*common.BigInt)(balance),
+// 					BalanceStr:      value.Balance,
+// 					Symbol:          dataValue.Symbol,
+// 					ContractAddress: "0x00",
+// 					TokenId:         "0x00",
+// 				}
+// 				abrpsList = append(abrpsList, abrps)
+// 			}
+// 		}
+// 	} else {
+// 		apiUrl := fmt.Sprintf("api/v5/explorer/address/token-balance-multi?chainShortName=%s&address=%s&protocolType=%s&page=%s&limit=%s", request.ChainShortName, result, request.ProtocolType[0], request.Page[0], request.Limit[0])
+// 		fmt.Println("apiUrlapiUrl===", apiUrl)
+// 		var responseData []AddressTokenBalanceMultiData
+// 		err := cea.baseClient.Call("oklink", "", "", apiUrl, nil, &responseData)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 		for _, dataValue := range responseData {
+// 			for _, token := range dataValue.BalanceList {
+// 				balance, _ := new(big.Int).SetString(token.HoldingAmount, 10)
+// 				abrps := &account.AccountBalanceResponse{
+// 					Account:         token.Address,
+// 					Balance:         (*common.BigInt)(balance),
+// 					BalanceStr:      token.HoldingAmount,
+// 					Symbol:          "unknown",
+// 					ContractAddress: token.TokenContractAddress,
+// 					TokenId:         "0x00",
+// 				}
+// 				abrpsList = append(abrpsList, abrps)
+// 			}
+// 		}
+// 	}
+// 	return abrpsList, nil
+// }

--- a/explorer/oklink/token.go
+++ b/explorer/oklink/token.go
@@ -49,3 +49,48 @@ func (cea *ChainExplorerAdaptor) GetTokenList(request *token.TokenRequest) ([]to
 	}
 	return responseList, nil
 }
+
+// GET /api/v5/explorer/nft/nft-details
+func (cea *ChainExplorerAdaptor) GetNFTDetails(request *token.GetNFTDetailsRequest) (*token.GetNFTDetailsResponse, error) {
+	var response []*NFTDetailsData
+	apiUrl := fmt.Sprintf("api/v5/explorer/nft/nft-details?chainShortName=%s&tokenContractAddress=%s&tokenId=%s",
+		request.ChainShortName, request.ContractAddress, request.TokenId)
+	err := cea.baseClient.Call("oklink", "", "", apiUrl, nil, &response)
+	if err != nil {
+		return nil, err
+	}
+	if len(response) > 0 {
+		data := response[0]
+		attributes := make([]token.Attributes, len(data.Attributes))
+		for i, attr := range data.Attributes {
+			attributes[i] = token.Attributes{
+				TraitType:  attr.TraitType,
+				Value:      attr.Value,
+				Prevalence: attr.Prevalence,
+			}
+		}
+		result := token.GetNFTDetailsResponse{
+			CollectionName:       data.CollectionName,
+			TokenContractAddress: data.TokenContractAddress,
+			TokenId:              data.TokenId,
+			ProtocolType:         data.ProtocolType,
+			Token:                data.Token,
+			OwnerAddress:         data.OwnerAddress,
+			LogoUrl:              data.LogoUrl,
+			LastPrice:            data.LastPrice,
+			FloorPrice:           data.FloorPrice,
+			LastPriceUnit:        data.LastPriceUnit,
+			LastTransactionTime:  data.LastTransactionTime,
+			LastHeight:           data.LastHeight,
+			LastTxid:             data.LastTxid,
+			TransactionCount:     data.TransactionCount,
+			MinterAddress:        data.MinterAddress,
+			StorageMethod:        data.StorageMethod,
+			MintTime:             data.MintTime,
+			Title:                data.Title,
+			Attributes:           attributes,
+		}
+		return &result, nil
+	}
+	return nil, nil
+}

--- a/explorer/oklink/types.go
+++ b/explorer/oklink/types.go
@@ -121,3 +121,31 @@ type AddressUtxoUtxo struct {
 	UnspentAmount string `json:"unspentAmount"`
 	Index         string `json:"index"`
 }
+
+type NFTDetailsData struct {
+	CollectionName       string       `json:"collectionName"`       // Project name (full name)
+	TokenContractAddress string       `json:"tokenContractAddress"` // Project contract address
+	TokenId              string       `json:"tokenId"`              // NFT token ID
+	ProtocolType         string       `json:"protocolType"`         // NFT contract type
+	Token                string       `json:"token"`                // Token name
+	OwnerAddress         string       `json:"ownerAddress"`         // NFT holder address
+	LogoUrl              string       `json:"logoUrl"`              // NFT image URL
+	LastPrice            string       `json:"lastPrice"`            // Latest price of the NFT
+	FloorPrice           string       `json:"floorPrice"`           // Floor price of the NFT
+	LastPriceUnit        string       `json:"lastPriceUnit"`        // Price unit
+	LastTransactionTime  string       `json:"lastTransactionTime"`  // Latest transaction time, Unix timestamp in milliseconds, e.g., 1597026383085
+	LastHeight           string       `json:"lastHeight"`           // Block height of the latest transaction
+	LastTxid             string       `json:"lastTxid"`             // Hash of the latest transaction
+	TransactionCount     string       `json:"transactionCount"`     // Number of transactions for this NFT
+	MinterAddress        string       `json:"minterAddress"`        // NFT creator address
+	StorageMethod        string       `json:"storageMethod"`        // NFT storage method
+	MintTime             string       `json:"mintTime"`             // NFT minting time
+	Title                string       `json:"title"`                // Name property in NFT metadata, can be ENS or DID
+	Attributes           []Attributes `json:"attributes"`           // Attributes
+}
+
+type Attributes struct {
+	TraitType  string `json:"traitType"`  // Attribute category
+	Value      string `json:"value"`      // Attribute value
+	Prevalence string `json:"prevalence"` // Attribute rarity, expressed as decimal, 0.1=10%
+}

--- a/explorer/solscan/account.go
+++ b/explorer/solscan/account.go
@@ -1,12 +1,14 @@
 package solscan
 
 import (
+	"errors"
 	"fmt"
+	"math/big"
+	"strconv"
+
 	"github.com/dapplink-labs/chain-explorer-api/common"
 	"github.com/dapplink-labs/chain-explorer-api/common/account"
 	"github.com/dapplink-labs/chain-explorer-api/common/chain"
-	"math/big"
-	"strconv"
 )
 
 // GetAccountBalance 获取账户余额
@@ -141,4 +143,9 @@ func (cea *ChainExplorerAdaptor) GetTxByAddress(request *account.AccountTxReques
 			TransactionList: transactionList,
 		}, nil
 	}
+}
+
+func (cea *ChainExplorerAdaptor) GetAccountBalanceV2(request *account.GetAccountBalanceRequest) (*account.GetAccountBalanceResponse, error) {
+	//todo implement
+	return nil, errors.New("not implement")
 }

--- a/explorer/solscan/token.go
+++ b/explorer/solscan/token.go
@@ -2,9 +2,10 @@ package solscan
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/dapplink-labs/chain-explorer-api/common"
 	"github.com/dapplink-labs/chain-explorer-api/common/token"
-	"strconv"
 )
 
 var pageSizes = []string{"10", "20", "30", "40", "60", "100"}
@@ -44,4 +45,9 @@ func (cea *ChainExplorerAdaptor) GetTokenList(req *token.TokenRequest) ([]token.
 		})
 	}
 	return responseList, nil
+}
+
+func (cea *ChainExplorerAdaptor) GetNFTDetails(request *token.GetNFTDetailsRequest) (*token.GetNFTDetailsResponse, error) {
+	//todo implement
+	return nil, fmt.Errorf("not implemented")
 }


### PR DESCRIPTION
发现旧接口存在局限，对接oklink数据存在一些问题，比如分页、对nft不支持等
// GetAccountBalance 获取账户余额
GetAccountBalance(req *account.AccountBalanceRequest) (*account.AccountBalanceResponse, error)
// GetMultiAccountBalance 获取多个账户余额
GetMultiAccountBalance(req *account.AccountBalanceRequest) ([]*account.AccountBalanceResponse, error)
优化后添加以下接口
// GetAccountBalanceV2 同时支持单账户/多账户+原生代币/合约代币
GetAccountBalanceV2(req *account.GetAccountBalanceRequest) (*account.GetAccountBalanceResponse, error)
// GetNFTDetails 获取NFT代币详情
GetNFTDetails(req *token.GetNFTDetailsRequest) (*token.GetNFTDetailsResponse, error)